### PR TITLE
Recursive scene discovery

### DIFF
--- a/interfaces/fmask_sentinel2Stacked.py
+++ b/interfaces/fmask_sentinel2Stacked.py
@@ -68,11 +68,12 @@ def mainRoutine(cmdargs):
     fmaskFilenames = config.FmaskFilenames()
     fmaskFilenames.setTOAReflectanceFile(cmdargs.toa)
     fmaskFilenames.setOutputCloudMaskFile(cmdargs.output)
+    #fmaskFilenames.setOutputCloudMaskFile(out)
 
     fmaskConfig = config.FmaskConfig(config.FMASK_SENTINEL2)
     fmaskConfig.setAnglesInfo(anglesInfo)
     fmaskConfig.setKeepIntermediates(cmdargs.keepintermediates)
-    fmaskConfig.setVerbose(cmdargs.verbose)
+    #fmaskConfig.setVerbose(cmdargs.verbose)
     fmaskConfig.setTempDir(cmdargs.tempdir)
     fmaskConfig.setTOARefScaling(10000.0)
     fmaskConfig.setMinCloudSize(cmdargs.mincloudsize)

--- a/interfaces/fmask_sentinel2Stacked.py
+++ b/interfaces/fmask_sentinel2Stacked.py
@@ -68,12 +68,11 @@ def mainRoutine(cmdargs):
     fmaskFilenames = config.FmaskFilenames()
     fmaskFilenames.setTOAReflectanceFile(cmdargs.toa)
     fmaskFilenames.setOutputCloudMaskFile(cmdargs.output)
-    #fmaskFilenames.setOutputCloudMaskFile(out)
 
     fmaskConfig = config.FmaskConfig(config.FMASK_SENTINEL2)
     fmaskConfig.setAnglesInfo(anglesInfo)
     fmaskConfig.setKeepIntermediates(cmdargs.keepintermediates)
-    #fmaskConfig.setVerbose(cmdargs.verbose)
+    fmaskConfig.setVerbose(cmdargs.verbose)
     fmaskConfig.setTempDir(cmdargs.tempdir)
     fmaskConfig.setTOARefScaling(10000.0)
     fmaskConfig.setMinCloudSize(cmdargs.mincloudsize)

--- a/interfaces/s2meta.py
+++ b/interfaces/s2meta.py
@@ -1,10 +1,25 @@
 import os
 import glob
+import fnmatch
 
+
+def recursive_glob(rootdir='.', pattern='*'):
+    """Search recursively for files matching a specified pattern.
+
+    Adapted from http://stackoverflow.com/questions/2186525/use-a-glob-to-find-files-recursively-in-python
+    """
+
+    matches = []
+    for root, dirnames, filenames in os.walk(rootdir):
+        for filename in fnmatch.filter(filenames, pattern):
+            matches.append(os.path.join(root, filename))
+
+    return matches
 
 def find_xml_in_granule_dir(granuledir):
     pattern = os.path.join(granuledir, '*.xml')
-    xmlfiles = glob.glob(pattern)
+    #xmlfiles = glob.glob(pattern)
+    xmlfiles = recursive_glob(granuledir, pattern='*MTD*TL*.xml')
     if len(xmlfiles) != 1:
         raise RuntimeError('Expecting exactly one XML file in granules dir. Found {} with pattern \'{}\'.',format(len(xmlfiles), pattern))
     return xmlfiles[0]

--- a/interfaces/s2meta.py
+++ b/interfaces/s2meta.py
@@ -1,25 +1,20 @@
 import os
-import glob
 import fnmatch
 
 
-def recursive_glob(rootdir='.', pattern='*'):
-    """Search recursively for files matching a specified pattern.
-
-    Adapted from http://stackoverflow.com/questions/2186525/use-a-glob-to-find-files-recursively-in-python
-    """
-
+def recursive_glob(rootdir, pattern='*'):
     matches = []
-    for root, dirnames, filenames in os.walk(rootdir):
+    for root, _, filenames in os.walk(rootdir):
         for filename in fnmatch.filter(filenames, pattern):
             matches.append(os.path.join(root, filename))
-
     return matches
+
 
 def find_xml_in_granule_dir(granuledir):
     pattern = os.path.join(granuledir, '*.xml')
-    #xmlfiles = glob.glob(pattern)
     xmlfiles = recursive_glob(granuledir, pattern='*MTD*TL*.xml')
     if len(xmlfiles) != 1:
-        raise RuntimeError('Expecting exactly one XML file in granules dir. Found {} with pattern \'{}\'.',format(len(xmlfiles), pattern))
+        raise RuntimeError(
+            'Expecting exactly one XML file in granules dir. Found {} with pattern \'{}\'.'
+            .format(len(xmlfiles), pattern))
     return xmlfiles[0]

--- a/qgis_fmask_sentinel2Stacked.py
+++ b/qgis_fmask_sentinel2Stacked.py
@@ -2,21 +2,22 @@
 #==================================
 ##FMask=group
 ##FMask Sentinel 2=name
-##ParameterFile|granuledir|Image Directory (For images including subimages use target granule directory)|True|False
+##ParameterFile|granuledir|Path to .SAFE or tile/granule directory|True|False
 ##ParameterFile|anglesfile|Input angles file containing satellite and sun azimuth and zenith|False|True|
+##OutputFile|output|Output cloud mask|tif
 ##ParameterNumber|mincloudsize|Mininum cloud size (in pixels) to retain, before any buffering|0|None|0
 ##ParameterNumber|cloudbufferdistance|Distance (in metres) to buffer final cloud objects|0|None|150
 ##ParameterNumber|shadowbufferdistance|Distance (in metres) to buffer final cloud shadow objects|0|None|300
 ##ParameterNumber|cloudprobthreshold|Cloud probability threshold (percentage) (Eqn 17)|0|100|20
 ##*ParameterNumber|nirsnowthreshold|Threshold for NIR reflectance for snow detection (Eqn 20). Increase this to reduce snow commission errors|0|1|0.11
 ##*ParameterNumber|greensnowthreshold|Threshold for Green reflectance for snow detection (Eqn 20). Increase this to reduce snow commission errors|0|1|0.1
+##*ParameterBoolean|verbose|verbose output|True
 
 from argparse import Namespace
 import sys
 import os.path
 import tempfile
 import shutil
-from glob import glob
 from processing.tools import dataobjects
 
 here = os.path.dirname(scriptDescriptionFile)
@@ -48,17 +49,11 @@ try:
             mainRoutine_angles(cmdargs_angles)
         progress.setConsoleInfo('Done.')
 
-    dirs = [x[0] for x in os.walk(granuledir)]
-    for dir in dirs:
-        if 'IMG_DATA' in dir:
-            scene = os.path.basename(glob(os.path.join(dir, '*.jp2'))[0])[:-8]
-            outpath = os.path.join(dir, scene + '_fmask.tif')
-
     cmdargs = Namespace(
             toa=tempvrt,
             anglesfile=anglesfile,
-            output=outpath,
-            #verbose=verbose,
+            output=output,
+            verbose=verbose,
             tempdir=tempdir,
             keepintermediates=False,
             mincloudsize=mincloudsize,
@@ -67,10 +62,6 @@ try:
             cloudprobthreshold=cloudprobthreshold,
             nirsnowthreshold=nirsnowthreshold,
             greensnowthreshold=greensnowthreshold)
-
-
-
-
 
     progress.setConsoleInfo('Running FMask (this may take a while) ...')
     with redirect_print(progress):
@@ -82,8 +73,4 @@ finally:
         pass
 
 progress.setConsoleInfo('Done.')
-dataobjects.load(outpath, os.path.basename(outpath))
-
-
-#OutputFile|output|Output cloud mask|tif
-#*ParameterBoolean|verbose|verbose output|True
+dataobjects.load(output, os.path.basename(output))

--- a/qgis_fmask_sentinel2Stacked.py
+++ b/qgis_fmask_sentinel2Stacked.py
@@ -5,13 +5,13 @@
 ##ParameterFile|granuledir|Path to .SAFE or tile/granule directory|True|False
 ##ParameterFile|anglesfile|Input angles file containing satellite and sun azimuth and zenith|False|True|
 ##OutputFile|output|Output cloud mask|tif
+##*ParameterBoolean|verbose|verbose output|True
 ##ParameterNumber|mincloudsize|Mininum cloud size (in pixels) to retain, before any buffering|0|None|0
 ##ParameterNumber|cloudbufferdistance|Distance (in metres) to buffer final cloud objects|0|None|150
 ##ParameterNumber|shadowbufferdistance|Distance (in metres) to buffer final cloud shadow objects|0|None|300
 ##ParameterNumber|cloudprobthreshold|Cloud probability threshold (percentage) (Eqn 17)|0|100|20
 ##*ParameterNumber|nirsnowthreshold|Threshold for NIR reflectance for snow detection (Eqn 20). Increase this to reduce snow commission errors|0|1|0.11
 ##*ParameterNumber|greensnowthreshold|Threshold for Green reflectance for snow detection (Eqn 20). Increase this to reduce snow commission errors|0|1|0.1
-##*ParameterBoolean|verbose|verbose output|True
 
 from argparse import Namespace
 import sys

--- a/stacks/sentinel_stack.py
+++ b/stacks/sentinel_stack.py
@@ -1,15 +1,31 @@
 import os
 import glob
+import fnmatch
 
 from .buildvrt import buildvrt
+
+
+def recursive_glob(rootdir='.', pattern='*'):
+    """Search recursively for files matching a specified pattern.
+
+    Adapted from http://stackoverflow.com/questions/2186525/use-a-glob-to-find-files-recursively-in-python
+    """
+
+    matches = []
+    for root, dirnames, filenames in os.walk(rootdir):
+        for filename in fnmatch.filter(filenames, pattern):
+            matches.append(os.path.join(root, filename))
+
+    return matches
 
 
 def create_sentinel_stack(granuledir, outfile):
     infiles = []
     for fnpattern in ['*_B0[1-8].jp2', '*_B8A.jp2', '*_B09.jp2', '*_B1[0-2].jp2']:
-        pattern = os.path.join(granuledir, 'IMG_DATA', fnpattern)
-        bandfiles = sorted(glob.glob(pattern))
-        if not bandfiles:
-            raise RuntimeError('No files found for pattern \'{}\'.'.format(pattern))
+        #pattern = os.path.join(granuledir, 'IMG_DATA', fnpattern)
+        bandfiles = recursive_glob(rootdir=granuledir, pattern=fnpattern)
+        #bandfiles = sorted(glob.glob(pattern))
+        #if not bandfiles:
+        #    raise RuntimeError('No files found for pattern \'{}\'.'.format(pattern))
         infiles += bandfiles
     buildvrt(infiles, outfile, resolution='user', separate=True, extra=['-tr', '20', '20'])

--- a/stacks/sentinel_stack.py
+++ b/stacks/sentinel_stack.py
@@ -1,31 +1,22 @@
 import os
-import glob
 import fnmatch
 
 from .buildvrt import buildvrt
 
 
-def recursive_glob(rootdir='.', pattern='*'):
-    """Search recursively for files matching a specified pattern.
-
-    Adapted from http://stackoverflow.com/questions/2186525/use-a-glob-to-find-files-recursively-in-python
-    """
-
+def recursive_glob(rootdir, pattern='*'):
     matches = []
-    for root, dirnames, filenames in os.walk(rootdir):
+    for root, _, filenames in os.walk(rootdir):
         for filename in fnmatch.filter(filenames, pattern):
             matches.append(os.path.join(root, filename))
-
     return matches
 
 
 def create_sentinel_stack(granuledir, outfile):
     infiles = []
     for fnpattern in ['*_B0[1-8].jp2', '*_B8A.jp2', '*_B09.jp2', '*_B1[0-2].jp2']:
-        #pattern = os.path.join(granuledir, 'IMG_DATA', fnpattern)
         bandfiles = recursive_glob(rootdir=granuledir, pattern=fnpattern)
-        #bandfiles = sorted(glob.glob(pattern))
-        #if not bandfiles:
-        #    raise RuntimeError('No files found for pattern \'{}\'.'.format(pattern))
+        if not bandfiles:
+            raise RuntimeError('No files found for pattern \'{}\'.'.format(fnpattern))
         infiles += bandfiles
     buildvrt(infiles, outfile, resolution='user', separate=True, extra=['-tr', '20', '20'])


### PR DESCRIPTION
The QGIS scripts for FMASK on Sentinel 2 data currently take the granule directory (below `GRANULES`) as input. For the now-standard single-product files, they should also be able to take the path to the `.SAFE` file as input and discover the granule data themselves.

Cleaned-up version of #1 